### PR TITLE
Registers an offence even if the line includes a end-of-line # comment

### DIFF
--- a/lib/rubocop/cop/grep/grep.rb
+++ b/lib/rubocop/cop/grep/grep.rb
@@ -21,8 +21,8 @@ module RuboCop
               re = Regexp.new(pat, opt)
               from = 0
               while m = re.match(source, from)
-                if match_comment || !in_comment?(m)
-                  pos = position_from_matchdata(m)
+                pos = position_from_matchdata(m)
+                if match_comment || !in_comment?(pos)
                   range = source_range(processed_source.buffer, pos[:line], pos[:column], pos[:length])
                   add_offense(range, message: rule['Message'])
                 end
@@ -42,8 +42,7 @@ module RuboCop
           { line: line, column: column, length: length }
         end
 
-        private def in_comment?(m)
-          pos = position_from_matchdata(m)
+        private def in_comment?(pos)
           processed_source.comments.any? do |c|
             c.loc.line == pos[:line] && c.loc.expression.begin_pos <= pos[:column]
           end

--- a/lib/rubocop/cop/grep/grep.rb
+++ b/lib/rubocop/cop/grep/grep.rb
@@ -43,8 +43,10 @@ module RuboCop
         end
 
         private def in_comment?(m)
-          line = position_from_matchdata(m)[:line]
-          processed_source.comments.any? { |c| c.loc.line == line }
+          pos = position_from_matchdata(m)
+          processed_source.comments.any? do |c|
+            c.loc.line == pos[:line] && c.loc.expression.begin_pos <= pos[:column]
+          end
         end
 
         private def regexp_option(rule)

--- a/sig/_shim.rbs
+++ b/sig/_shim.rbs
@@ -1,0 +1,11 @@
+module Parser
+  module Source
+    class Map
+      def expression: () -> Parser::Source::Range
+    end
+
+    class Range
+      def begin_pos: () -> Integer
+    end
+  end
+end

--- a/sig/rubocop/cop/cop/grep.rbs
+++ b/sig/rubocop/cop/cop/grep.rbs
@@ -27,7 +27,11 @@ module RuboCop
           length: Integer,
         }
 
-        private def in_comment?: (MatchData) -> bool
+        private def in_comment?: ({
+          line: Integer,
+          column: Integer,
+          length: Integer,
+        }) -> bool
 
         private def regexp_option: (rule) -> Integer
 

--- a/spec/rubocop/cop/grep/grep_spec.rb
+++ b/spec/rubocop/cop/grep/grep_spec.rb
@@ -36,6 +36,32 @@ RSpec.describe RuboCop::Cop::Grep::Grep, :config do
         # foo
       RUBY
     end
+
+    it 'registers an offence even if the line includes a end-of-line # comment' do
+      expect_offense(<<~RUBY)
+        foo bar # comment
+        ^^^ foo is bad
+      RUBY
+    end
+
+    it 'does not register an offence when `# rubocop:disable`' do
+      expect_no_offenses(<<~RUBY)
+        foo bar # rubocop:disable all
+      RUBY
+    end
+
+    it 'does not register an offence when `# rubocop:disable Grep/Grep`' do
+      expect_no_offenses(<<~RUBY)
+        foo bar # rubocop:disable Grep/Grep
+      RUBY
+    end
+
+    it 'registers an offence `# rubocop:disable` is irrelevant one' do
+      expect_offense(<<~RUBY)
+        foo bar # rubocop:disable Foo/Bar
+        ^^^ foo is bad
+      RUBY
+    end
   end
 
   context 'with a config including multiple rules' do


### PR DESCRIPTION
While using rubocop-grep, I realized that lines with end-of-line `#` comments cannot be detected by rubocop as violations, even if they do violate a rule.


I have expressed this behavior in a spec. The current codebase does not pass this test.

```ruby
  context 'with a simple config' do
    let(:cop_config) { {
      'Rules' => [
        { 'Pattern' => 'foo', 'Message' => 'foo is bad' },
      ],
    } }

    ....
    it 'registers an offence even if the line includes a end-of-line # comment' do
      expect_offense(<<~RUBY)
        foo bar # comment
        ^^^ foo is bad
      RUBY
    end
```

This PR resolves this issue.

