### PR TITLE
Add `Rules` to config/default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,4 +3,5 @@
 Grep/Grep:
   Description: 'It is a RuboCop extension to define your own cop with regexps.'
   Enabled: true
+  Rules: []
   VersionAdded: '0.1'


### PR DESCRIPTION
To avoid warning `Warning: Grep/Grep does not support Rules parameter.`

### Problem: warning message

> ```
> $ bundle exec rubocop
> Warning: Grep/Grep does not support Rules parameter.
> 
> Supported parameters are:
> 
>   - Enabled
> 
> Inspecting 1 file
> .
> 
> 1 file inspected, no offenses detected
> ```


### Detail

This warning originates from the following section of rubocop/rubocop:

https://github.com/rubocop/rubocop/blob/f9b3b1ed1ddb6129cd5bf7c16824261041f107d5/lib/rubocop/config_validator.rb#L179-L204

> ```ruby
>     def each_invalid_parameter(cop_name)
>       default_config = ConfigLoader.default_configuration[cop_name]
> 
>       @config[cop_name].each_key do |param|
>         next if COMMON_PARAMS.include?(param) || default_config.key?(param)
> 
>         supported_params = default_config.keys - INTERNAL_PARAMS
> 
>         yield param, supported_params
>       end
>     end
> ```

Focusing on the `default_config.key?(param)` part, it seems that if the parameter in question exists in the default config (config/default.yml of each gem), the warning display can be prevented.

Looking at how other gems handle this:

According to the comment in rubocop-grep at https://github.com/route06/rubocop-grep/blob/e750001d064c9434175491265affc0fea356dfad/lib/rubocop/grep/inject.rb#L3
> ```ruby
>  # The original code is from https://github.com/rubocop/rubocop-rspec/blob/master/lib/rubocop/rspec/inject.rb
>```

The `lib/rubocop/grep/inject.rb` is utilizing `lib/rubocop/rspec/inject.rb` from rubocop-rspec.

Rubocop-rspec defines additional parameters for each cop in `config/default.yml`.

For example, the `RSpec/Dialect` has an additional parameter named `PreferredMethods`:

https://github.com/rubocop/rubocop-rspec/blob/ecd945f5e49b6006c2a7f314d7570ed449afc6dc/config/default.yml#L301
> ```yaml
> RSpec/Dialect:
>   Description: Enforces custom RSpec dialects.
>   Enabled: false
>   PreferredMethods: {}
>   VersionAdded: '1.33'
>   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
> ```

Therefore, I considered resolving this by adding `Rules` as an additional parameter, similar to `PreferredMethods: {}`.